### PR TITLE
[ROS-O] remove use of deprecated _1

### DIFF
--- a/allocators/CMakeLists.txt
+++ b/allocators/CMakeLists.txt
@@ -13,9 +13,11 @@ catkin_package(
     LIBRARIES # TODO
 )
 
-catkin_add_gtest(test_aligned_alloc test/test_aligned_alloc.cpp)## Generate added messages and services with any dependencies listed here
-target_link_libraries(test_aligned_alloc ${Boost_LIBRARIES} ${catkin_LIBRARIES})
-#add_dependencies(test_aligned_alloc allocators_gencpp)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_aligned_alloc test/test_aligned_alloc.cpp)## Generate added messages and services with any dependencies listed here
+  target_link_libraries(test_aligned_alloc ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+  #add_dependencies(test_aligned_alloc allocators_gencpp)
+endif()
 
 install(DIRECTORY test/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/allocators/CMakeLists.txt
+++ b/allocators/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED )
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 catkin_package(
-    DEPENDS include # TODO add dependencies
+    DEPENDS # TODO add dependencies
     CATKIN_DEPENDS # TODO
     INCLUDE_DIRS include # TODO include
     LIBRARIES # TODO

--- a/lockfree/CMakeLists.txt
+++ b/lockfree/CMakeLists.txt
@@ -16,14 +16,15 @@ add_library(${PROJECT_NAME} src/free_list.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 #add_dependencies(${PROJECT_NAME} )
 
-catkin_add_gtest(test_freelist test/test_freelist.cpp)
-target_link_libraries(test_freelist ${PROJECT_NAME})
-#add_dependencies(test_freelist )
+if(CATKIN_ENABLE_TESTING)
+   catkin_add_gtest(test_freelist test/test_freelist.cpp)
+   target_link_libraries(test_freelist ${PROJECT_NAME})
+   #add_dependencies(test_freelist )
 
-catkin_add_gtest(test_object_pool test/test_object_pool.cpp)
-target_link_libraries(test_object_pool ${PROJECT_NAME})
-#add_dependencies(test_object_pool )
-
+   catkin_add_gtest(test_object_pool test/test_object_pool.cpp)
+   target_link_libraries(test_object_pool ${PROJECT_NAME})
+   #add_dependencies(test_object_pool )
+endif()
 
 install(TARGETS ${PROJECT_NAME}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/rosatomic/CMakeLists.txt
+++ b/rosatomic/CMakeLists.txt
@@ -9,7 +9,10 @@ catkin_package(
     LIBRARIES # TODO
 )
 include_directories(include ${catkin_INCLUDE_DIRS})
-catkin_add_gtest(utest test/utest.cpp)
+
+if(CATKIN_ENABLE_TESTING)
+   catkin_add_gtest(utest test/utest.cpp)
+endif()
 
 
 install(DIRECTORY include/ros include/boost DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/rosrt/include/rosrt/subscriber.h
+++ b/rosrt/include/rosrt/subscriber.h
@@ -160,7 +160,8 @@ public:
   {
     ros::SubscribeOptions ops;
 #ifdef ROS_NEW_SERIALIZATION_API
-    ops.template init<M>(topic, 1, boost::bind(&Subscriber::callback, this, _1), boost::bind(&lockfree::ObjectPool<M>::allocateShared, pool_));
+    auto p{ pool_ };
+    ops.template init<M>(topic, 1, [this](auto msg){ callback(msg); }, [p](){ return p->allocateShared(); });
 #else
     ops.template init<M>(topic, 1, boost::bind(&Subscriber::callback, this, _1));
 #endif


### PR DESCRIPTION
remove non-included use of deprecated `_1`. It was implicitly included through ros_comm including `<boost/bind.hpp>` before, but that header has been deprecated for a long time in boost and triggers myriads of warnings when building ROS now. [ROS-O will probably remove it soon](https://github.com/ros-o/ros_comm/pull/3) and thus needs to fix the code here.

